### PR TITLE
Remove inline header height script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8739,16 +8739,6 @@
         }
     });
     
-    // B1: Function to measure and set header height as CSS variable
-    function updateHeaderHeight() {
-        var header = document.querySelector('.dashboard-header');
-        if (!header) return;
-        var totalHeight = header.offsetHeight;
-        document.documentElement.style.setProperty('--header-h', totalHeight + 'px');
-        if (window.CFODashboard && window.CFODashboard.log) {
-            window.CFODashboard.log('info', 'headerHeightUpdated', { height: totalHeight + 'px' });
-        }
-    }
     
     // Expose API for external integrations
     window.printCurrentPage = printCurrentPage;
@@ -8929,12 +8919,6 @@
         // Инициализируем error boundary первым
         errorBoundary.init();
         
-        // B1: Update header height on window resize and element changes
-        var headerEl = document.querySelector('.dashboard-header');
-        window.addEventListener('resize', updateHeaderHeight);
-        if (headerEl && window.ResizeObserver) {
-            new ResizeObserver(updateHeaderHeight).observe(headerEl);
-        }
         
         try {
             // Инициализируем переключатели, фильтры, алерты, навигацию по страницам, плотность и клавиатурную навигацию
@@ -8950,9 +8934,6 @@
             
             // Загружаем конфигурацию алертов
             loadAlertsConfig();
-            
-            // B1: Set CSS variable for header height to fix content overlap
-            updateHeaderHeight();
             
             // F2: Apply visual optimizations after UI initialization
             setTimeout(() => {


### PR DESCRIPTION
## Summary
- drop duplicate `updateHeaderHeight` implementation and related event hooks from `index.html`
- keep single implementation in `dashboard.bundle.js` executing on `DOMContentLoaded`

## Testing
- `node --check dashboard.bundle.js`
- `npx -y htmlhint index.html`
- `python3 - <<'PY'\nfrom playwright.sync_api import sync_playwright\nimport pathlib\nwith sync_playwright() as p:\n    browser = p.chromium.launch()\n    page = browser.new_page()\n    page.goto('file://' + str(pathlib.Path('index.html').resolve()))\n    initial = page.evaluate("getComputedStyle(document.documentElement).getPropertyValue('--header-h').trim()")\n    page.evaluate("document.querySelector('.dashboard-header').style.paddingTop='50px'")\n    page.wait_for_timeout(200)\n    updated = page.evaluate("getComputedStyle(document.documentElement).getPropertyValue('--header-h').trim()")\n    print('initial:', initial, 'updated:', updated)\n    browser.close()\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68a4a9c32c94832c98ad7287ff833ac1